### PR TITLE
Fix typo in function name when running module directly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ function generateRandomAnimal() {
 }
 
 if (require.main === module) {
-  console.log(generateAnimal())
+  console.log(generateRandomAnimal())
 }
 
 module.exports = generateRandomAnimal


### PR DESCRIPTION
```js
if (require.main === module) {
  console.log(generateAnimal())
}
```
This code contains an undefined function name, `generateAnimal()`.

This pull request renames the function to `generateRandomAnimal()`
